### PR TITLE
package: add "component" section

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,10 @@
   ],
   "scripts": {
     "test": "tap --stderr --tap ./test"
+  },
+  "component": {
+    "scripts": {
+      "to-array/index.js": "index.js"
+    }
   }
 }


### PR DESCRIPTION
This isn't an npm thing, nor a component(1) thing, but
our (cloudup's) app currently uses a custom builder that
reads this "component" section of the package.json file.

@raynos I hate to ask you to merge config in the package.json that doesn't actually affect you at all, but if you don't mind the extra field, it would save me some copy & paste code on the client-side (the node, server-side of this works fine). If you don't wanna merge that's fine and I'll just point the builder to my fork instead.

Cheers!
